### PR TITLE
Add BoardGame entity with cards

### DIFF
--- a/backend/src/main/kotlin/com/example/cardgenerator/boardgame/BoardGame.kt
+++ b/backend/src/main/kotlin/com/example/cardgenerator/boardgame/BoardGame.kt
@@ -9,6 +9,7 @@ class BoardGame(
     val id: Long = 0,
     var title: String = "",
     var overview: String = "",
+    var tags: String? = null,
     @Column(columnDefinition = "TEXT")
     var data: String? = null,
     var createdAt: LocalDateTime = LocalDateTime.now(),

--- a/backend/src/main/kotlin/com/example/cardgenerator/boardgame/BoardGame.kt
+++ b/backend/src/main/kotlin/com/example/cardgenerator/boardgame/BoardGame.kt
@@ -1,27 +1,16 @@
-package com.example.cardgenerator.card
+package com.example.cardgenerator.boardgame
 
-import com.example.cardgenerator.boardgame.BoardGame
 import jakarta.persistence.*
 import java.time.LocalDateTime
 
 @Entity
-class Card(
+class BoardGame(
     @Id @GeneratedValue(strategy = GenerationType.IDENTITY)
     val id: Long = 0,
-
-    @ManyToOne(fetch = FetchType.LAZY)
-    @JoinColumn(name = "board_game_id")
-    var boardGame: BoardGame? = null,
-
-    var name: String = "",
-
-    var image: String? = null,
-
-    var description: String = "",
-
+    var title: String = "",
+    var overview: String = "",
     @Column(columnDefinition = "TEXT")
     var data: String? = null,
-
     var createdAt: LocalDateTime = LocalDateTime.now(),
     var updatedAt: LocalDateTime = LocalDateTime.now()
 )

--- a/backend/src/main/kotlin/com/example/cardgenerator/boardgame/BoardGameController.kt
+++ b/backend/src/main/kotlin/com/example/cardgenerator/boardgame/BoardGameController.kt
@@ -1,0 +1,14 @@
+package com.example.cardgenerator.boardgame
+
+import org.springframework.web.bind.annotation.*
+
+@RestController
+@RequestMapping("/api/boardgames")
+class BoardGameController(private val repository: BoardGameRepository) {
+
+    @GetMapping
+    fun all(): List<BoardGame> = repository.findAll()
+
+    @PostMapping
+    fun add(@RequestBody boardGame: BoardGame): BoardGame = repository.save(boardGame)
+}

--- a/backend/src/main/kotlin/com/example/cardgenerator/boardgame/BoardGameRepository.kt
+++ b/backend/src/main/kotlin/com/example/cardgenerator/boardgame/BoardGameRepository.kt
@@ -1,0 +1,5 @@
+package com.example.cardgenerator.boardgame
+
+import org.springframework.data.jpa.repository.JpaRepository
+
+interface BoardGameRepository : JpaRepository<BoardGame, Long>

--- a/backend/src/main/kotlin/com/example/cardgenerator/card/Card.kt
+++ b/backend/src/main/kotlin/com/example/cardgenerator/card/Card.kt
@@ -15,9 +15,13 @@ class Card(
 
     var name: String = "",
 
+    var type: String = "",
+
     var image: String? = null,
 
     var description: String = "",
+
+    var tags: String? = null,
 
     @Column(columnDefinition = "TEXT")
     var data: String? = null,

--- a/backend/src/main/kotlin/com/example/cardgenerator/card/CardController.kt
+++ b/backend/src/main/kotlin/com/example/cardgenerator/card/CardController.kt
@@ -7,7 +7,8 @@ import org.springframework.web.bind.annotation.*
 class CardController(private val repository: CardRepository) {
 
     @GetMapping
-    fun all(): List<Card> = repository.findAll()
+    fun all(@RequestParam(required = false) boardGameId: Long?): List<Card> =
+        boardGameId?.let { repository.findByBoardGameId(it) } ?: repository.findAll()
 
     @PostMapping
     fun add(@RequestBody card: Card): Card = repository.save(card)

--- a/backend/src/main/kotlin/com/example/cardgenerator/card/CardRepository.kt
+++ b/backend/src/main/kotlin/com/example/cardgenerator/card/CardRepository.kt
@@ -2,4 +2,6 @@ package com.example.cardgenerator.card
 
 import org.springframework.data.jpa.repository.JpaRepository
 
-interface CardRepository : JpaRepository<Card, Long>
+interface CardRepository : JpaRepository<Card, Long> {
+    fun findByBoardGameId(boardGameId: Long): List<Card>
+}

--- a/backend/src/test/kotlin/com/example/cardgenerator/boardgame/BoardGameAndCardRepositoryTest.kt
+++ b/backend/src/test/kotlin/com/example/cardgenerator/boardgame/BoardGameAndCardRepositoryTest.kt
@@ -1,0 +1,28 @@
+package com.example.cardgenerator.boardgame
+
+import com.example.cardgenerator.card.Card
+import com.example.cardgenerator.card.CardRepository
+import io.kotest.core.spec.style.StringSpec
+import io.kotest.matchers.shouldBe
+import org.springframework.beans.factory.annotation.Autowired
+import org.springframework.boot.test.context.SpringBootTest
+
+@SpringBootTest
+class BoardGameAndCardRepositoryTest @Autowired constructor(
+    private val boardGameRepository: BoardGameRepository,
+    private val cardRepository: CardRepository
+) : StringSpec({
+    "save board game with tags" {
+        val bg = BoardGame(title = "BG", overview = "o", tags = "t1,t2")
+        val saved = boardGameRepository.save(bg)
+        saved.tags shouldBe "t1,t2"
+    }
+
+    "save card with type and tags" {
+        val bg = boardGameRepository.save(BoardGame(title = "BG2", overview = "o"))
+        val card = Card(boardGame = bg, name = "c1", type = "spell", tags = "a,b")
+        val saved = cardRepository.save(card)
+        saved.type shouldBe "spell"
+        saved.tags shouldBe "a,b"
+    }
+})


### PR DESCRIPTION
## Summary
- support board games and cards relation
- include endpoints to manage board games and filter cards

## Testing
- `gradle test --no-daemon` *(fails: plugin not found)*

------
https://chatgpt.com/codex/tasks/task_e_683fd575908883288f6f580b5163c41d